### PR TITLE
Autotune example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ cert.pem
 chain.pem
 cacert.pem
 cbl.txt
+.idea
+.vscode

--- a/as/etc/aerospike_ssd.conf
+++ b/as/etc/aerospike_ssd.conf
@@ -1,16 +1,16 @@
 # Aerospike database configuration file for deployments using raw storage.
 
 service {
-	user root
-	group root
-	pidfile /var/run/aerospike/asd.pid
-	proto-fd-max 15000
+	user albert
+	group albert
+	# pidfile /var/run/aerospike/asd.pid
+	proto-fd-max 1024
 	cluster-name cakery
 }
 
 logging {
 	# Log file must be an absolute path.
-	file /var/log/aerospike/aerospike.log {
+	console {
 		context any info
 	}
 }
@@ -51,7 +51,8 @@ namespace test {
 		# Use one or more lines like those below with actual device paths.
 #		device /dev/sdb
 #		device /dev/sdc
-
+		file /opt/aerospike/data/bar.dat
+		filesize 4G
 		flush-size 128K
 	}
 }

--- a/as/etc/aerospike_ssd.conf
+++ b/as/etc/aerospike_ssd.conf
@@ -1,16 +1,16 @@
 # Aerospike database configuration file for deployments using raw storage.
 
 service {
-	user albert
-	group albert
-	# pidfile /var/run/aerospike/asd.pid
-	proto-fd-max 1024
+	user root
+	group root
+	pidfile /var/run/aerospike/asd.pid
+	proto-fd-max 15000
 	cluster-name cakery
 }
 
 logging {
 	# Log file must be an absolute path.
-	console {
+	file /var/log/aerospike/aerospike.log {
 		context any info
 	}
 }
@@ -51,8 +51,7 @@ namespace test {
 		# Use one or more lines like those below with actual device paths.
 #		device /dev/sdb
 #		device /dev/sdc
-		file /opt/aerospike/data/bar.dat
-		filesize 4G
+
 		flush-size 128K
 	}
 }

--- a/as/include/base/datamodel.h
+++ b/as/include/base/datamodel.h
@@ -56,7 +56,7 @@
 #include "fabric/partition.h"
 #include "storage/flat.h"
 #include "storage/storage.h"
-
+#include "base/datamodel.h"
 
 #define OBJ_SIZE_HIST_NUM_BUCKETS 1024
 #define TTL_HIST_NUM_BUCKETS 100

--- a/as/include/base/thr_info_port.h
+++ b/as/include/base/thr_info_port.h
@@ -25,6 +25,7 @@
 #include "socket.h"
 
 void as_info_port_start();
+void as_defrag_tuner_start();
 
 extern cf_serv_cfg g_info_bind;
 extern cf_ip_port g_info_port;

--- a/as/src/base/as.c
+++ b/as/src/base/as.c
@@ -418,6 +418,7 @@ as_run(int argc, char **argv)
 	as_nsup_start();			// may send evict-void-time(s) to other nodes
 	as_service_start();			// server will now receive client transactions
 	as_info_port_start();		// server will now receive info transactions
+	as_defrag_tuner_start();	// start the defrag tuner
 	as_ticker_start();			// only after everything else is started
 
 	// Relevant for enterprise edition only.

--- a/as/src/base/cfg_info.c
+++ b/as/src/base/cfg_info.c
@@ -185,7 +185,7 @@ as_cfg_info_cmd_config_set(const char* name, const char* params, cf_dyn_buf* db)
 {
 	cf_mutex_lock(&g_set_cfg_lock);
 
-	cfg_set(name, params, db);
+	cfg_set(NULL, params, db);
 
 	cf_mutex_unlock(&g_set_cfg_lock);
 }

--- a/as/src/base/namespace.c
+++ b/as/src/base/namespace.c
@@ -128,7 +128,7 @@ as_namespace_create(char *name)
 
 	ns->storage_type = AS_STORAGE_ENGINE_UNDEFINED;
 
-	ns->storage_defrag_lwm_pct = 50; // defrag if occupancy of block is < 50%
+	ns->storage_defrag_lwm_pct = 10; // defrag if occupancy of block is < 50%
 	ns->storage_defrag_sleep = 1000; // sleep this many microseconds between each wblock
 	ns->storage_encryption = AS_ENCRYPTION_AES_128;
 	ns->storage_flush_max_us = 1000 * 1000; // wait this many microseconds before flushing inactive current write buffer (0 = never)

--- a/as/src/base/thr_info_port.c
+++ b/as/src/base/thr_info_port.c
@@ -206,22 +206,23 @@ thr_info_port_writable(info_port_state *ips)
 void *
 run_defrag_tuner(void *arg)
 {
+	cf_info(AS_INFO, "defrag tuner started");
   	// TODO: Add flag to allow user to stop this loop
   	// run indefinitely
 	while (42 == 42) {
-		cf_info(AS_INFO, "in loop");
+
         sleep(1);
         // loop through each namespace
         cf_dyn_buf db;
         cf_dyn_buf_init_heap(&db, 128);
-        char *cmd = (char*)malloc(128 * sizeof(char));
+		char *cmd = (char*)malloc(128 * sizeof(char));
 
-        // goal: change exactly 1 config parameter per namespace to get defrag in better shape.
-        // asinfo command is executed at the bottom
+		// goal: change exactly 1 config parameter per namespace to get defrag in better shape.
+		// asinfo command is executed at the bottom
 		for (uint32_t ns_ix = 0; ns_ix < g_config.n_namespaces; ns_ix++) {
 			uint32_t avail_pct;
-            struct as_namespace_s *ns = g_config.namespaces[ns_ix];
-            // fetch current avail_pct from as_storage_stats
+			struct as_namespace_s *ns = g_config.namespaces[ns_ix];
+			// fetch current avail_pct from as_storage_stats
             as_storage_stats(ns, &avail_pct, NULL);
             uint32_t current_lwm = ns->storage_defrag_lwm_pct;
             uint32_t current_defrag_sleep = ns->storage_defrag_sleep;
@@ -235,12 +236,6 @@ run_defrag_tuner(void *arg)
                     current_lwm,
                     current_defrag_sleep
                     );
-            // TODO: specify limits. Should allow the operator to specify upper/lower LWM bound, and to disable autotuning
-//            if (current_lwm >= 50){
-//              cf_info(AS_INFO, "Current lwm above 50: %u, not tuning", current_lwm);
-//            	break;
-//            }
-
 
             // add a ticker to output the defrag/write-q as observed from this function
             uint32_t defrag_q_sz_total = 0;

--- a/as/src/storage/drv_ssd.c
+++ b/as/src/storage/drv_ssd.c
@@ -2302,10 +2302,10 @@ ssd_defrag_sweep(drv_ssd *ssd)
 		ssd_wblock_state *p_wblock_state = &ssd->wblock_state[wblock_id];
 
 		cf_mutex_lock(&p_wblock_state->LOCK);
-
+		// TODO: inuse_sz is in-memory, right? This is cheap I think?
 		if (p_wblock_state->state == WBLOCK_STATE_USED &&
-				p_wblock_state->inuse_sz < ssd->ns->defrag_lwm_size &&
-				! p_wblock_state->short_lived) {
+				p_wblock_state->inuse_sz < ssd->ns->defrag_lwm_size) {
+
 			push_wblock_to_defrag_q(ssd, wblock_id);
 			n_queued++;
 		}
@@ -2409,6 +2409,7 @@ run_ssd_maintenance(void *udata)
 		if (ssd->defrag_sweep != 0) {
 			// May take long enough to mess up other jobs' schedules, but it's a
 			// very rare manually-triggered intervention.
+                        // lol
 			ssd_defrag_sweep(ssd);
 			as_decr_uint32(&ssd->defrag_sweep);
 		}


### PR DESCRIPTION
Remove the need to tune lwm if system is in a steady/stable state. This is not a finished product, but enough to illustrate the idea.
We can have a thread that runs in the background to inspect the running system (perhaps tie to defrag/nsup later?) and make informed decisions about adjusting the defrag-sleep and defrag-lwm. The idea is to always be in-flux in order to maintain a close-to-perfect set of tunings, depending on inputs.

Inputs: 
- target avail% range (ex. between 20 and 30%)
- tuning frequency (1s in this current impl)
- target defrag-q range (ex between 100 and 10000000)
- lwm-range (ex. between 1 and 80% LWM)
- write-q limit (do not make defrag more aggressive if write-q above some limit)

Output:
- Each aerospike server instance can automatically tune itself as the stable state changes, optimizing for a balance between avail runway and write-amplification.
- Heterogeneous clusters are more simple to maintain (ex. clusters with 800SLC drives mixed with 15TB QLC drives need different tuning)
- Operators can be abstracted away from tuning, making the product more of a 'set and forget' 

```mermaid
flowchart TD
    A[Start defrag tuner loop] --> B[Sleep 1 second]
    B --> C[Loop through each namespace]
    C --> D[Get avail_pct, current_lwm, current_defrag_sleep]
    D --> E[Get defrag_q_sz_total and write_q_sz_total]

    E --> F{Check thresholds}
    
    F --> G1[Below avail threshold?]
    G1 -->|Yes| H1{IO limited? write-q high}
    H1 -->|Yes| I1[Abort - IO limited]
    H1 -->|No| J1{Defrag piled up? defrag-q high}
    J1 -->|Yes| K1{Below defrag sleep target?}
    K1 -->|Yes| L1[Abort - already low defrag sleep]
    K1 -->|No| M1[Decrease defrag sleep by 20%]
    M1 --> Z[Apply change, exit loop]
    J1 -->|No| N1{Above defrag LWM limit?}
    N1 -->|Yes| O1[Abort - LWM at max limit]
    N1 -->|No| P1[Increase LWM by 20%]
    P1 --> Z

    G1 -->|No| G2[Above avail threshold?]
    G2 -->|Yes| H2{Below defrag LWM limit?}
    H2 -->|Yes| I2[Decrease LWM by 1]
    H2 -->|No| J2{Above defrag sleep threshold?}
    J2 -->|No| K2[Increase defrag sleep by 20%]
    K2 --> Z
    J2 -->|Yes| Z
    G2 -->|No| Z

    Z --> B

    style A fill:#f9f,stroke:#333,stroke-width:2px

```